### PR TITLE
Add Laravel 5.8/Nova 2.0 support

### DIFF
--- a/src/Traits/HasSubfields.php
+++ b/src/Traits/HasSubfields.php
@@ -80,7 +80,7 @@ trait HasSubfields
     {
         $this->inverseRelationship = $inverseRelationship;
 
-        $this->inverseRelationshipKey = $this->resourceInstance::newModel()->{$inverseRelationship}()->getForeignKey();
+        $this->inverseRelationshipKey = $this->resourceInstance::newModel()->{$inverseRelationship}()->getForeignKeyName();
 
         return $this;
     }


### PR DESCRIPTION
Just updated to Laravel 5.8 and Nova 2.0 and I ran into an error because the `getForeignKey` function has been renamed `getForeignKeyName`. 

This PR simply changes the `HasSubfields` trait to use the updated function name. However, the update will break backwards functionality with Laravel 5.7/Nova 1.0, so it might make sense to also tie this PR to Nova 2.0 and above.