### PR TITLE
Fixed issue #71

### DIFF
--- a/src/NestedForm.php
+++ b/src/NestedForm.php
@@ -565,7 +565,7 @@ class NestedForm extends Field
                 'min' => $this->min,
                 'max' => $this->isManyRelationsip() ? $this->max : 1,
                 'displayIf' => isset($this->displayIfCallback) ? call_user_func($this->displayIfCallback) : null
-            ],
+            ]
         );
     }
 }


### PR DESCRIPTION
This pull request solves issue #71 which caused error messages with the text `syntax error, unexpected ')'` and being unable to use the package effectively.