### PR TITLE
Fixed issue #74

### DIFF
--- a/src/NestedForm.php
+++ b/src/NestedForm.php
@@ -63,6 +63,20 @@ class NestedForm extends Field
     public $component = 'nested-form';
 
     /**
+     * Indicates if the element should be shown on the index view.
+     *
+     * @var \Closure|bool
+     */
+    public $showOnIndex = false;
+
+    /**
+     * Indicates if the element should be shown on the detail view.
+     *
+     * @var \Closure|bool
+     */
+    public $showOnDetail = false;
+
+    /**
      * The field's relationship resource class.
      * 
      * @var string


### PR DESCRIPTION
This pull request solves issue #74 which caused the appearance of an empty nested form in the Detail view of a resource and the impossibility of hiding it using `hideFromDetail`.

More specifically, it sets the properties `showOnIndex` and `showOnDetail` (inherited from the `Field` class) to `false` within `src/NestedForm.php`.