### PR TITLE
fix open() type hint

### DIFF
--- a/src/NestedForm.php
+++ b/src/NestedForm.php
@@ -2,6 +2,7 @@
 
 namespace Yassi\NestedForm;
 
+use function GuzzleHttp\json_encode;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
@@ -20,9 +21,8 @@ use Laravel\Nova\Http\Requests\DetachResourceRequest;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Http\Requests\UpdateResourceRequest;
 use Laravel\Nova\Nova;
-use Laravel\Nova\Panel;
 
-use function GuzzleHttp\json_encode;
+use Laravel\Nova\Panel;
 
 class NestedForm extends Field
 {
@@ -249,7 +249,7 @@ class NestedForm extends Field
      * 
      * @param boolean $opened
      */
-    public function open(boolean $opened)
+    public function open(bool $opened)
     {
         $this->opened = $opened;
 


### PR DESCRIPTION
# Bug

When using `open(true)`. It throws an error saying :
```Argument 1 passed to Yassi\NestedForm\NestedForm::open() must be an instance of phpDocumentor\Reflection\Types\Boolean, boolean given```

### Environment
PHP 7.3.9
Laravel 6.0.3
Laravel Nova 2.3.0

---

# Fix

Changing the typehint from `boolean` to `bool` fixes the problem.