### PR TITLE
change `boolean` to `bool`

### DIFF
--- a/src/NestedForm.php
+++ b/src/NestedForm.php
@@ -249,7 +249,7 @@ class NestedForm extends Field
      * 
      * @param boolean $opened
      */
-    public function open(boolean $opened)
+    public function open(bool $opened)
     {
         $this->opened = $opened;
 


### PR DESCRIPTION
In order to fix 

```
Argument 1 passed to Yassi\NestedForm\NestedForm::open() must be an instance of Yassi\NestedForm\boolean, bool given
```

error