### PR TITLE
fix to support Nova v2.7.1

### DIFF
--- a/src/NestedFormSchema.php
+++ b/src/NestedFormSchema.php
@@ -140,7 +140,7 @@ class NestedFormSchema implements JsonSerializable
 
         $method->setAccessible(true);
 
-        return $method->invoke($this->resourceInstance(), $this->request, collect($this->resourceInstance()->fields($this->request))
+        return $method->invoke($this->resourceInstance(), $this->request, $this->resourceInstance()->availableFields($this->request)
             ->reject(function ($field) {
                 return $this->parentForm->isRelatedField($field);
             })->map(function ($field) {


### PR DESCRIPTION
Nova 2.7.1 requires usage of `FieldCollection` instead of a standard collection or array in some places. I had an exception and this PR fixes it by using the `availableFields` (which returns a `FieldCollection`) instead of `fields` method (which usually returns an array).

Thanks.