### PR TITLE
Update DeleteResourceRequest

### DIFF
--- a/src/NestedForm.php
+++ b/src/NestedForm.php
@@ -470,6 +470,9 @@ class NestedForm extends Field
     protected function getDeleteRequest(NovaRequest $request, $model, $children)
     {
         return DeleteResourceRequest::createFrom($request->replace([
+            'viaResource' => null,
+            'viaResourceId' => null,
+            'viaRelationship' => null,
             'resources' => $model->{$this->viaRelationship}()->whereNotIn($this->keyName, $children->pluck($this->keyName))->pluck($this->keyName)
         ]));
     }


### PR DESCRIPTION
This PR updates getDeleteRequest method in order to force via* attributes to null value.
If the original request, the main resource form, has these parameters, they will be proxied to the ResourceDeleteController and they cause weird a behavior.

Forcing them to null prevent any issues.