### PR TITLE
fix wrong placement of } causing failure to create new entries

### DIFF
--- a/src/NestedForm.php
+++ b/src/NestedForm.php
@@ -344,7 +344,7 @@ class NestedForm extends Field
     {
         if ($model->exists) {
             $newRequest = NovaRequest::createFrom($request);
-            if (!$model->{$model->getKeyName() && $request->has($model->getKeyName())}) {
+            if (!$model->{$model->getKeyName()} && $request->has($model->getKeyName())) {
                 $model->{$model->getKeyName()} = $request->get($model->getKeyName());
             }
             $children = collect($newRequest->get($requestAttribute));


### PR DESCRIPTION
The latest patch has wrong placement of } causing error:

SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'actionable_id' cannot be null 

when trying to create new instance