### PR TITLE
Use primary key attribute value instead of 'id'

### DIFF
--- a/src/NestedForm.php
+++ b/src/NestedForm.php
@@ -497,10 +497,10 @@ class NestedForm extends Field
     {
         $createRequest = CreateResourceRequest::createFrom($request->replace([
             'viaResource' => $this->viaResource,
-            'viaResourceId' => $model->id,
+            'viaResourceId' => $model->getKey(),
             'viaRelationship' => $this->viaRelationship
         ])->merge($child)->merge(collect($relatedKeys)->map(function ($value) use ($model) {
-            return $value === self::ID ? $model->id : $value;
+            return $value === self::ID ? $model->getKey() : $value;
         })->toArray()));
 
         $createRequest->files = collect($request->file($requestAttribute . '.' . $index));

--- a/src/NestedForm.php
+++ b/src/NestedForm.php
@@ -471,7 +471,7 @@ class NestedForm extends Field
     {
         return DetachResourceRequest::createFrom($request->replace([
             'viaResource' => $this->viaResource,
-            'viaResourceId' => $model->id,
+            'viaResourceId' => $model->getKey(),
             'viaRelationship' => $this->viaRelationship,
             'resources' => $model->{$this->viaRelationship}()->select($this->attribute . '.' . $this->keyName)->whereNotIn($this->attribute . '.' . $this->keyName, $children->pluck($this->keyName))->pluck($this->keyName)
         ]));

--- a/src/NestedFormChild.php
+++ b/src/NestedFormChild.php
@@ -33,8 +33,8 @@ class NestedFormChild extends NestedFormSchema
     public function jsonSerialize()
     {
         return array_merge(parent::jsonSerialize(), [
-            'resourceId' => $this->model->id,
-            $this->parentForm->keyName => $this->model->id
+            'resourceId' => $this->model->getKey(),
+            $this->parentForm->keyName => $this->model->getKey(),
         ]);
     }
 }


### PR DESCRIPTION
I have a set of models that use non-default primary key names to preserve the ability to perform natural joins (`series_id` for `series`, etc). When I attempt to save a form, I receive an error that a null primary key value is attempted in the transaction. Rather than assuming the primary key is an `id` attribute, we should resolve the primary key attribute of the model through `getKey()`.

Thanks for developing this useful package! Let me know if I need to clarify this change further or if I am missing anything with these changes.